### PR TITLE
Add error location metadata to formatted output

### DIFF
--- a/internal/verror/context.go
+++ b/internal/verror/context.go
@@ -143,7 +143,11 @@ func FormatErrorWithContext(err *Error) string {
 	case 900:
 		category = "Internal"
 	}
-	parts = append(parts, fmt.Sprintf("** %s Error (%s)", category, err.ID))
+	header := fmt.Sprintf("** %s Error (%s)", category, err.ID)
+	if err.File != "" {
+		header = fmt.Sprintf("%s:%d:%d %s", err.File, err.Line, err.Column, header)
+	}
+	parts = append(parts, header)
 
 	// Error message
 	parts = append(parts, err.Message)

--- a/internal/verror/error.go
+++ b/internal/verror/error.go
@@ -13,6 +13,9 @@ type Error struct {
 	Near     string   // String representation of near context (values formatted)
 	Where    []string // Call stack (most recent first)
 	Message  string   // Formatted message
+	File     string
+	Line     int
+	Column   int
 }
 
 // NewError creates an error with given category, ID, and arguments.
@@ -34,7 +37,12 @@ func (e *Error) Error() string {
 	var sb strings.Builder
 
 	// Main error line
-	sb.WriteString(fmt.Sprintf("%s error (%d): %s\n", e.Category, e.Code, e.Message))
+	header := fmt.Sprintf("%s error (%d): %s", e.Category, e.Code, e.Message)
+	if e.File != "" {
+		header = fmt.Sprintf("%s:%d:%d %s", e.File, e.Line, e.Column, header)
+	}
+	sb.WriteString(header)
+	sb.WriteString("\n")
 
 	// Near context (if available)
 	if e.Near != "" {
@@ -58,6 +66,13 @@ func (e *Error) SetNear(near string) *Error {
 // SetWhere adds call stack context.
 func (e *Error) SetWhere(where []string) *Error {
 	e.Where = where
+	return e
+}
+
+func (e *Error) SetLocation(file string, line, column int) *Error {
+	e.File = file
+	e.Line = line
+	e.Column = column
 	return e
 }
 

--- a/internal/verror/error_test.go
+++ b/internal/verror/error_test.go
@@ -1,0 +1,66 @@
+package verror
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestErrorStringLocation(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *Error
+		want string
+	}{
+		{
+			name: "without location",
+			err:  NewSyntaxError(ErrIDInvalidSyntax, [3]string{"token", "", ""}),
+			want: "Syntax error (200): Invalid syntax: token",
+		},
+		{
+			name: "with location",
+			err:  NewSyntaxError(ErrIDInvalidSyntax, [3]string{"token", "", ""}).SetLocation("script.viro", 12, 5),
+			want: "script.viro:12:5 Syntax error (200): Invalid syntax: token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.err.Error()
+			line := strings.SplitN(got, "\n", 2)[0]
+
+			if line != tt.want {
+				t.Fatalf("Error() header mismatch\nwant: %q\ngot: %q", tt.want, line)
+			}
+		})
+	}
+}
+
+func TestFormatErrorWithContextLocation(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *Error
+		want string
+	}{
+		{
+			name: "without location",
+			err:  NewSyntaxError(ErrIDInvalidSyntax, [3]string{"token", "", ""}),
+			want: "** Syntax Error (invalid-syntax)",
+		},
+		{
+			name: "with location",
+			err:  NewSyntaxError(ErrIDInvalidSyntax, [3]string{"token", "", ""}).SetLocation("script.viro", 12, 5),
+			want: "script.viro:12:5 ** Syntax Error (invalid-syntax)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatErrorWithContext(tt.err)
+			line := strings.SplitN(got, "\n", 2)[0]
+
+			if line != tt.want {
+				t.Fatalf("FormatErrorWithContext() header mismatch\nwant: %q\ngot: %q", tt.want, line)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add file, line, and column metadata to verror.Error and expose a SetLocation helper
- prefix formatted error output with the captured location when available
- cover the new formatting behavior with unit tests

## Testing
- go test ./internal/verror...


------
https://chatgpt.com/codex/tasks/task_e_690cd09e307c832abcc7b4e34c8526e3