### PR TITLE
Add source-aware parsing error reporting

### DIFF
--- a/internal/native/parse.go
+++ b/internal/native/parse.go
@@ -21,6 +21,7 @@ func NativeTokenize(args []core.Value, refValues map[string]core.Value, eval cor
 	input := inputVal.String()
 
 	tokenizer := tokenize.NewTokenizer(input)
+	tokenizer.SetSource("(native)")
 	tokens, err := tokenizer.Tokenize()
 	if err != nil {
 		return value.NewNoneVal(), err
@@ -40,7 +41,7 @@ func NativeTokenize(args []core.Value, refValues map[string]core.Value, eval cor
 
 func createTokenObject(tok tokenize.Token) core.Value {
 	objFrame := frame.NewFrame(frame.FrameObject, -1)
-	
+
 	tokenType := getTokenTypeName(tok.Type)
 	objFrame.Bind("type", value.NewWordVal(tokenType))
 	objFrame.Bind("value", value.NewStrVal(tok.Value))
@@ -88,7 +89,7 @@ func NativeParse(args []core.Value, refValues map[string]core.Value, eval core.E
 		return value.NewNoneVal(), err
 	}
 
-	parser := parse.NewParser(tokens)
+	parser := parse.NewParser(tokens, "")
 	values, err := parser.Parse()
 	if err != nil {
 		if vErr, ok := err.(*verror.Error); ok {
@@ -189,7 +190,7 @@ func NativeLoadString(args []core.Value, refValues map[string]core.Value, eval c
 	}
 	input := inputVal.String()
 
-	values, err := parse.Parse(input)
+	values, err := parse.ParseWithSource(input, "(native)")
 	if err != nil {
 		return value.NewNoneVal(), err
 	}
@@ -208,8 +209,9 @@ func NativeClassify(args []core.Value, refValues map[string]core.Value, eval cor
 	}
 	input := inputVal.String()
 
-	parser := parse.NewParser([]tokenize.Token{})
-	val, err := parser.ClassifyLiteral(input)
+	parser := parse.NewParser([]tokenize.Token{}, "(native)")
+	token := tokenize.Token{Type: tokenize.TokenLiteral, Value: input, Line: 1, Column: 1, Source: "(native)"}
+	val, err := parser.ClassifyLiteral(token)
 	if err != nil {
 		if vErr, ok := err.(*verror.Error); ok {
 			return value.NewNoneVal(), vErr

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -7,37 +7,51 @@ import (
 )
 
 func Parse(input string) ([]core.Value, error) {
+	return ParseWithSource(input, "")
+}
+
+func ParseWithSource(input, source string) ([]core.Value, error) {
 	tokenizer := tokenize.NewTokenizer(input)
+	tokenizer.SetSource(source)
 	tokens, err := tokenizer.Tokenize()
 	if err != nil {
-		if vErr, ok := err.(*verror.Error); ok {
-			if input != "" {
-				vErr.SetNear(input)
-			}
-			return nil, vErr
-		}
-		vErr := verror.NewSyntaxError(verror.ErrIDInvalidSyntax, [3]string{err.Error(), "", ""})
-		if input != "" {
-			vErr.SetNear(input)
-		}
-		return nil, vErr
+		return nil, enrichParseError(err, input, source)
 	}
 
-	parser := NewParser(tokens)
+	parser := NewParser(tokens, source)
 	values, err := parser.Parse()
 	if err != nil {
-		if vErr, ok := err.(*verror.Error); ok {
-			if input != "" {
-				vErr.SetNear(input)
-			}
-			return nil, vErr
-		}
-		vErr := verror.NewSyntaxError(verror.ErrIDInvalidSyntax, [3]string{err.Error(), "", ""})
-		if input != "" {
-			vErr.SetNear(input)
-		}
-		return nil, vErr
+		return nil, enrichParseError(err, input, source)
 	}
 
 	return values, nil
+}
+
+func enrichParseError(err error, input, source string) error {
+	if vErr, ok := err.(*verror.Error); ok {
+		if input != "" {
+			vErr.SetNear(input)
+		}
+		if vErr.File == "" && source != "" {
+			line := vErr.Line
+			column := vErr.Column
+			if line == 0 {
+				line = 1
+			}
+			if column == 0 {
+				column = 1
+			}
+			vErr.SetLocation(source, line, column)
+		}
+		return vErr
+	}
+
+	vErr := verror.NewSyntaxError(verror.ErrIDInvalidSyntax, [3]string{err.Error(), "", ""})
+	if input != "" {
+		vErr.SetNear(input)
+	}
+	if source != "" {
+		vErr.SetLocation(source, 1, 1)
+	}
+	return vErr
 }

--- a/internal/parse/parse_bench_test.go
+++ b/internal/parse/parse_bench_test.go
@@ -87,7 +87,7 @@ func BenchmarkParseSimple(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		p := NewParser(tokens)
+		p := NewParser(tokens, "")
 		_, err := p.Parse()
 		if err != nil {
 			b.Fatal(err)
@@ -107,7 +107,7 @@ func BenchmarkParseMedium(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		p := NewParser(tokens)
+		p := NewParser(tokens, "")
 		_, err := p.Parse()
 		if err != nil {
 			b.Fatal(err)
@@ -136,7 +136,7 @@ result: fib 10
 	b.ResetTimer()
 
 	for b.Loop() {
-		p := NewParser(tokens)
+		p := NewParser(tokens, "")
 		_, err := p.Parse()
 		if err != nil {
 			b.Fatal(err)
@@ -156,7 +156,7 @@ func BenchmarkParseBlock(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		p := NewParser(tokens)
+		p := NewParser(tokens, "")
 		_, err := p.Parse()
 		if err != nil {
 			b.Fatal(err)
@@ -176,7 +176,7 @@ func BenchmarkParsePath(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		p := NewParser(tokens)
+		p := NewParser(tokens, "")
 		_, err := p.Parse()
 		if err != nil {
 			b.Fatal(err)

--- a/internal/parse/semantic_parser_test.go
+++ b/internal/parse/semantic_parser_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/marcin-radoszewski/viro/internal/value"
 )
 
+func literalToken(value string) tokenize.Token {
+	return tokenize.Token{Type: tokenize.TokenLiteral, Value: value, Line: 1, Column: 1, Source: "(test)"}
+}
+
 func TestParser_ClassifyLiteral_Integers(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -23,8 +27,8 @@ func TestParser_ClassifyLiteral_Integers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewParser([]tokenize.Token{})
-			result, err := p.ClassifyLiteral(tt.input)
+			p := NewParser([]tokenize.Token{}, "(test)")
+			result, err := p.ClassifyLiteral(literalToken(tt.input))
 			if err != nil {
 				t.Errorf("ClassifyLiteral() error = %v", err)
 				return
@@ -52,8 +56,8 @@ func TestParser_ClassifyLiteral_Decimals(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewParser([]tokenize.Token{})
-			result, err := p.ClassifyLiteral(tt.input)
+			p := NewParser([]tokenize.Token{}, "(test)")
+			result, err := p.ClassifyLiteral(literalToken(tt.input))
 			if err != nil {
 				t.Errorf("ClassifyLiteral() error = %v", err)
 				return
@@ -78,8 +82,8 @@ func TestParser_ClassifyLiteral_SetWords(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewParser([]tokenize.Token{})
-			result, err := p.ClassifyLiteral(tt.input)
+			p := NewParser([]tokenize.Token{}, "(test)")
+			result, err := p.ClassifyLiteral(literalToken(tt.input))
 			if err != nil {
 				t.Errorf("ClassifyLiteral() error = %v", err)
 				return
@@ -108,8 +112,8 @@ func TestParser_ClassifyLiteral_GetWords(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewParser([]tokenize.Token{})
-			result, err := p.ClassifyLiteral(tt.input)
+			p := NewParser([]tokenize.Token{}, "(test)")
+			result, err := p.ClassifyLiteral(literalToken(tt.input))
 			if err != nil {
 				t.Errorf("ClassifyLiteral() error = %v", err)
 				return
@@ -138,8 +142,8 @@ func TestParser_ClassifyLiteral_LitWords(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewParser([]tokenize.Token{})
-			result, err := p.ClassifyLiteral(tt.input)
+			p := NewParser([]tokenize.Token{}, "(test)")
+			result, err := p.ClassifyLiteral(literalToken(tt.input))
 			if err != nil {
 				t.Errorf("ClassifyLiteral() error = %v", err)
 				return
@@ -170,8 +174,8 @@ func TestParser_ClassifyLiteral_Words(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewParser([]tokenize.Token{})
-			result, err := p.ClassifyLiteral(tt.input)
+			p := NewParser([]tokenize.Token{}, "(test)")
+			result, err := p.ClassifyLiteral(literalToken(tt.input))
 			if err != nil {
 				t.Errorf("ClassifyLiteral() error = %v", err)
 				return
@@ -200,8 +204,8 @@ func TestParser_ClassifyLiteral_Datatypes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewParser([]tokenize.Token{})
-			result, err := p.ClassifyLiteral(tt.input)
+			p := NewParser([]tokenize.Token{}, "(test)")
+			result, err := p.ClassifyLiteral(literalToken(tt.input))
 			if err != nil {
 				t.Errorf("ClassifyLiteral() error = %v", err)
 				return
@@ -231,8 +235,8 @@ func TestParser_ClassifyLiteral_Paths(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewParser([]tokenize.Token{})
-			result, err := p.ClassifyLiteral(tt.input)
+			p := NewParser([]tokenize.Token{}, "(test)")
+			result, err := p.ClassifyLiteral(literalToken(tt.input))
 			if err != nil {
 				t.Errorf("ClassifyLiteral() error = %v", err)
 				return
@@ -246,7 +250,7 @@ func TestParser_ClassifyLiteral_Paths(t *testing.T) {
 
 func TestParser_ClassifyLiteral_SetPaths(t *testing.T) {
 	tests := []struct {
-		name string
+		name     string
 		input    string
 		wantType core.ValueType
 	}{
@@ -256,8 +260,8 @@ func TestParser_ClassifyLiteral_SetPaths(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewParser([]tokenize.Token{})
-			result, err := p.ClassifyLiteral(tt.input)
+			p := NewParser([]tokenize.Token{}, "(test)")
+			result, err := p.ClassifyLiteral(literalToken(tt.input))
 			if err != nil {
 				t.Errorf("ClassifyLiteral() error = %v", err)
 				return
@@ -281,8 +285,8 @@ func TestParser_ClassifyLiteral_GetPaths(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewParser([]tokenize.Token{})
-			result, err := p.ClassifyLiteral(tt.input)
+			p := NewParser([]tokenize.Token{}, "(test)")
+			result, err := p.ClassifyLiteral(literalToken(tt.input))
 			if err != nil {
 				t.Errorf("ClassifyLiteral() error = %v", err)
 				return
@@ -301,7 +305,7 @@ func TestParser_Parse_EmptyBlock(t *testing.T) {
 		{Type: tokenize.TokenEOF, Line: 1, Column: 3},
 	}
 
-	p := NewParser(tokens)
+	p := NewParser(tokens, "(test)")
 	result, err := p.Parse()
 	if err != nil {
 		t.Errorf("Parse() error = %v", err)
@@ -338,7 +342,7 @@ func TestParser_Parse_SimpleBlock(t *testing.T) {
 		{Type: tokenize.TokenEOF, Line: 1, Column: 8},
 	}
 
-	p := NewParser(tokens)
+	p := NewParser(tokens, "(test)")
 	result, err := p.Parse()
 	if err != nil {
 		t.Errorf("Parse() error = %v", err)
@@ -383,7 +387,7 @@ func TestParser_Parse_NestedBlocks(t *testing.T) {
 		{Type: tokenize.TokenEOF, Line: 1, Column: 10},
 	}
 
-	p := NewParser(tokens)
+	p := NewParser(tokens, "(test)")
 	result, err := p.Parse()
 	if err != nil {
 		t.Errorf("Parse() error = %v", err)
@@ -435,7 +439,7 @@ func TestParser_Parse_Parens(t *testing.T) {
 		{Type: tokenize.TokenEOF, Line: 1, Column: 8},
 	}
 
-	p := NewParser(tokens)
+	p := NewParser(tokens, "(test)")
 	result, err := p.Parse()
 	if err != nil {
 		t.Errorf("Parse() error = %v", err)
@@ -472,7 +476,7 @@ func TestParser_Parse_Mixed(t *testing.T) {
 		{Type: tokenize.TokenEOF, Line: 1, Column: 11},
 	}
 
-	p := NewParser(tokens)
+	p := NewParser(tokens, "(test)")
 	result, err := p.Parse()
 	if err != nil {
 		t.Errorf("Parse() error = %v", err)
@@ -501,7 +505,7 @@ func TestParser_Parse_UnclosedBlock(t *testing.T) {
 		{Type: tokenize.TokenEOF, Line: 1, Column: 5},
 	}
 
-	p := NewParser(tokens)
+	p := NewParser(tokens, "(test)")
 	_, err := p.Parse()
 	if err == nil {
 		t.Errorf("Parse() expected error for unclosed block, got nil")
@@ -514,7 +518,7 @@ func TestParser_Parse_UnexpectedClosingBracket(t *testing.T) {
 		{Type: tokenize.TokenEOF, Line: 1, Column: 2},
 	}
 
-	p := NewParser(tokens)
+	p := NewParser(tokens, "(test)")
 	_, err := p.Parse()
 	if err == nil {
 		t.Errorf("Parse() expected error for unexpected closing bracket, got nil")
@@ -522,8 +526,9 @@ func TestParser_Parse_UnexpectedClosingBracket(t *testing.T) {
 }
 
 func TestParser_ParsePath_SimpleWord(t *testing.T) {
-	p := NewParser([]tokenize.Token{})
-	segments, err := p.parsePath("obj.field")
+	p := NewParser([]tokenize.Token{}, "(test)")
+	token := literalToken("obj.field")
+	segments, err := p.parsePath(token, token.Value)
 	if err != nil {
 		t.Errorf("parsePath() error = %v", err)
 		return
@@ -544,8 +549,9 @@ func TestParser_ParsePath_SimpleWord(t *testing.T) {
 }
 
 func TestParser_ParsePath_IndexPath(t *testing.T) {
-	p := NewParser([]tokenize.Token{})
-	segments, err := p.parsePath("data.1")
+	p := NewParser([]tokenize.Token{}, "(test)")
+	token := literalToken("data.1")
+	segments, err := p.parsePath(token, token.Value)
 	if err != nil {
 		t.Errorf("parsePath() error = %v", err)
 		return
@@ -566,16 +572,18 @@ func TestParser_ParsePath_IndexPath(t *testing.T) {
 }
 
 func TestParser_ParsePath_EmptySegment(t *testing.T) {
-	p := NewParser([]tokenize.Token{})
-	_, err := p.parsePath("obj.")
+	p := NewParser([]tokenize.Token{}, "(test)")
+	token := literalToken("obj.")
+	_, err := p.parsePath(token, token.Value)
 	if err == nil {
 		t.Errorf("parsePath() expected error for empty segment, got nil")
 	}
 }
 
 func TestParser_ParsePath_EmptyPath(t *testing.T) {
-	p := NewParser([]tokenize.Token{})
-	_, err := p.parsePath("")
+	p := NewParser([]tokenize.Token{}, "(test)")
+	token := literalToken("")
+	_, err := p.parsePath(token, token.Value)
 	if err == nil {
 		t.Errorf("parsePath() expected error for empty path, got nil")
 	}

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -289,7 +289,7 @@ func (r *REPL) processLine(input string, interactive bool) {
 	}
 
 	joined := strings.Join(r.pendingLines, "\n")
-	values, err := parse.Parse(joined)
+	values, err := parse.ParseWithSource(joined, "(repl)")
 	if err != nil {
 		if shouldAwaitContinuation(err.(*verror.Error)) {
 			r.awaitingCont = true

--- a/internal/tokenize/tokenizer_test.go
+++ b/internal/tokenize/tokenizer_test.go
@@ -444,7 +444,8 @@ func tokensEqual(a, b []Token) bool {
 
 	for i := range a {
 		if a[i].Type != b[i].Type || a[i].Value != b[i].Value ||
-			a[i].Line != b[i].Line || a[i].Column != b[i].Column {
+			a[i].Line != b[i].Line || a[i].Column != b[i].Column ||
+			a[i].Source != b[i].Source {
 			return false
 		}
 	}

--- a/test/contract/action_benchmark_test.go
+++ b/test/contract/action_benchmark_test.go
@@ -13,7 +13,7 @@ func BenchmarkActionDispatch(b *testing.B) {
 	e := NewTestEvaluator()
 
 	// Parse once, evaluate many times
-	tokens, err := parse.Parse("first [1 2 3 4 5]")
+	tokens, err := parse.ParseWithSource("first [1 2 3 4 5]", "(test)")
 	if err != nil {
 		b.Fatalf("Parse error: %v", err)
 	}
@@ -31,7 +31,7 @@ func BenchmarkActionDispatch(b *testing.B) {
 func BenchmarkActionDispatchString(b *testing.B) {
 	e := NewTestEvaluator()
 
-	tokens, err := parse.Parse(`first "hello world"`)
+	tokens, err := parse.ParseWithSource(`first "hello world"`, "(test)")
 	if err != nil {
 		b.Fatalf("Parse error: %v", err)
 	}
@@ -50,7 +50,7 @@ func BenchmarkActionAppend(b *testing.B) {
 	e := NewTestEvaluator()
 
 	// Setup: Create a block variable
-	setupTokens, err := parse.Parse("b: [1 2 3]")
+	setupTokens, err := parse.ParseWithSource("b: [1 2 3]", "(test)")
 	if err != nil {
 		b.Fatalf("Parse error: %v", err)
 	}
@@ -60,7 +60,7 @@ func BenchmarkActionAppend(b *testing.B) {
 	}
 
 	// Parse append operation
-	tokens, err := parse.Parse("append b 4")
+	tokens, err := parse.ParseWithSource("append b 4", "(test)")
 	if err != nil {
 		b.Fatalf("Parse error: %v", err)
 	}
@@ -78,7 +78,7 @@ func BenchmarkActionAppend(b *testing.B) {
 func BenchmarkActionLength(b *testing.B) {
 	e := NewTestEvaluator()
 
-	tokens, err := parse.Parse("length? [1 2 3 4 5 6 7 8 9 10]")
+	tokens, err := parse.ParseWithSource("length? [1 2 3 4 5 6 7 8 9 10]", "(test)")
 	if err != nil {
 		b.Fatalf("Parse error: %v", err)
 	}
@@ -97,13 +97,13 @@ func BenchmarkTypeFrameLookup(b *testing.B) {
 	e := NewTestEvaluator()
 
 	// Parse multiple action calls to test dispatch overhead
-	tokens, err := parse.Parse(`
+	tokens, err := parse.ParseWithSource(`
 		first [1 2 3]
 		last [1 2 3]
 		first "hello"
 		last "world"
 		length? [1 2 3]
-	`)
+	`, "(test)")
 	if err != nil {
 		b.Fatalf("Parse error: %v", err)
 	}

--- a/test/contract/action_dispatch_test.go
+++ b/test/contract/action_dispatch_test.go
@@ -47,7 +47,7 @@ func TestActionDispatchBasics(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewTestEvaluator()
-			tokens, parseErr := parse.Parse(tt.input)
+			tokens, parseErr := parse.ParseWithSource(tt.input, "(test)")
 			if parseErr != nil {
 				t.Fatalf("Parse error: %v", parseErr)
 			}
@@ -90,7 +90,7 @@ func TestActionShadowing(t *testing.T) {
 		first 5
 	`
 
-	tokens, parseErr := parse.Parse(input)
+	tokens, parseErr := parse.ParseWithSource(input, "(test)")
 	if parseErr != nil {
 		t.Fatalf("Parse error: %v", parseErr)
 	}
@@ -117,7 +117,7 @@ func TestActionMultipleArguments(t *testing.T) {
 		b
 	`
 
-	tokens, parseErr := parse.Parse(input)
+	tokens, parseErr := parse.ParseWithSource(input, "(test)")
 	if parseErr != nil {
 		t.Fatalf("Parse error: %v", parseErr)
 	}

--- a/test/contract/errors_test.go
+++ b/test/contract/errors_test.go
@@ -190,7 +190,8 @@ outer 5`
 }
 
 func TestParse_UnclosedBlockError(t *testing.T) {
-	_, err := parse.Parse("[1 2 3")
+	sourceName := "test-script.viro"
+	_, err := parse.ParseWithSource("[1 2 3", sourceName)
 
 	if err == nil {
 		t.Fatalf("expected parse error but got none")
@@ -216,6 +217,14 @@ func TestParse_UnclosedBlockError(t *testing.T) {
 
 	if len(vErr.Where) != 0 {
 		t.Fatalf("parsing errors should not have call stack, got %v", vErr.Where)
+	}
+
+	if vErr.File != sourceName {
+		t.Fatalf("expected file %q, got %q", sourceName, vErr.File)
+	}
+
+	if vErr.Line == 0 || vErr.Column == 0 {
+		t.Fatalf("expected line and column to be set, got %d:%d", vErr.Line, vErr.Column)
 	}
 }
 

--- a/test/contract/function_eval_test.go
+++ b/test/contract/function_eval_test.go
@@ -18,7 +18,7 @@ func TestUserFunctionEvalFalse(t *testing.T) {
 		result: get-raw x
 	`
 	e := contract.NewTestEvaluator()
-	vals, err := parse.Parse(code)
+	vals, err := parse.ParseWithSource(code, "(test)")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestUserFunctionMixedEval(t *testing.T) {
 		result: type-check (2 + 2) (3 + 3)
 	`
 	e := contract.NewTestEvaluator()
-	vals, err := parse.Parse(code)
+	vals, err := parse.ParseWithSource(code, "(test)")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestNativeIfEvalArgs(t *testing.T) {
 		final: x
 	`
 	e := contract.NewTestEvaluator()
-	vals, err := parse.Parse(code)
+	vals, err := parse.ParseWithSource(code, "(test)")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestRefinementsAlwaysEvaluated(t *testing.T) {
 		result2: test-fn 1 2 --flag y
 	`
 	e := contract.NewTestEvaluator()
-	vals, err := parse.Parse(code)
+	vals, err := parse.ParseWithSource(code, "(test)")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +147,7 @@ func TestLitWordRefinementError(t *testing.T) {
 		quote-ref: fn ['--invalid] []
 	`
 	e := contract.NewTestEvaluator()
-	vals, err := parse.Parse(code)
+	vals, err := parse.ParseWithSource(code, "(test)")
 	if err != nil {
 		// If parser rejects it, that's also acceptable
 		return
@@ -168,7 +168,7 @@ func TestLitWordParameterReturnsValue(t *testing.T) {
 		type? result
 	`
 	e := contract.NewTestEvaluator()
-	vals, err := parse.Parse(code)
+	vals, err := parse.ParseWithSource(code, "(test)")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +192,7 @@ func TestUserFunctionNestedCalls(t *testing.T) {
 		result
 	`
 	e := contract.NewTestEvaluator()
-	vals, err := parse.Parse(code)
+	vals, err := parse.ParseWithSource(code, "(test)")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +218,7 @@ func TestTypeQueryLitWordArgument(t *testing.T) {
 		type? f word
 	`
 	e := contract.NewTestEvaluator()
-	vals, err := parse.Parse(code)
+	vals, err := parse.ParseWithSource(code, "(test)")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/contract/function_test.go
+++ b/test/contract/function_test.go
@@ -242,7 +242,7 @@ fact 5`)
 }
 
 func evalScriptWithEvaluator(src string) (*eval.Evaluator, core.Value, error) {
-	vals, err := parse.Parse(src)
+	vals, err := parse.ParseWithSource(src, "(test)")
 	if err != nil {
 		return nil, value.NewNoneVal(), err
 	}

--- a/test/contract/io_test.go
+++ b/test/contract/io_test.go
@@ -84,7 +84,7 @@ func TestIO_Print(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vals, perr := parse.Parse(tt.script)
+			vals, perr := parse.ParseWithSource(tt.script, "(test)")
 			if perr != nil {
 				t.Fatalf("Parse failed: %v", perr)
 			}
@@ -139,7 +139,7 @@ func TestIO_Input(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vals, parseErr := parse.Parse("input")
+			vals, parseErr := parse.ParseWithSource("input", "(test)")
 			if parseErr != nil {
 				t.Fatalf("Parse failed: %v", parseErr)
 			}

--- a/test/contract/native_scoping_test.go
+++ b/test/contract/native_scoping_test.go
@@ -65,7 +65,7 @@ func TestRefinementWithNativeName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := contract.NewTestEvaluator()
-			tokens, parseErr := parse.Parse(tt.code)
+			tokens, parseErr := parse.ParseWithSource(tt.code, "(test)")
 			if parseErr != nil {
 				t.Fatalf("parse error: %v", parseErr)
 			}
@@ -167,7 +167,7 @@ func TestLocalVariableWithNativeName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := contract.NewTestEvaluator()
-			tokens, parseErr := parse.Parse(tt.code)
+			tokens, parseErr := parse.ParseWithSource(tt.code, "(test)")
 			if parseErr != nil {
 				t.Fatalf("parse error: %v", parseErr)
 			}
@@ -295,7 +295,7 @@ func TestNestedScopeShadowing(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := contract.NewTestEvaluator()
-			tokens, parseErr := parse.Parse(tt.code)
+			tokens, parseErr := parse.ParseWithSource(tt.code, "(test)")
 			if parseErr != nil {
 				t.Fatalf("parse error: %v", parseErr)
 			}
@@ -335,7 +335,7 @@ func TestNativeFunctionsAccessible(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tokens, parseErr := parse.Parse(tt.code)
+			tokens, parseErr := parse.ParseWithSource(tt.code, "(test)")
 			if parseErr != nil {
 				t.Fatalf("parse error: %v", parseErr)
 			}

--- a/test/contract/object_frame_leak_test.go
+++ b/test/contract/object_frame_leak_test.go
@@ -10,7 +10,7 @@ import (
 func TestObjectFieldIsolation(t *testing.T) {
 	code := `o: object [a: 10]`
 
-	values, err := parse.Parse(code)
+	values, err := parse.ParseWithSource(code, "(test)")
 	if err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
@@ -33,7 +33,7 @@ func TestObjectFieldIsolation(t *testing.T) {
 
 	// Now try to lookup 'a' - it should NOT be found
 	code2 := `a`
-	values2, _ := parse.Parse(code2)
+	values2, _ := parse.ParseWithSource(code2, "(test)")
 	_, err2 := e.DoBlock(values2)
 
 	if err2 == nil {

--- a/test/contract/objects_test.go
+++ b/test/contract/objects_test.go
@@ -15,7 +15,7 @@ import (
 // These tests follow TDD: they MUST FAIL initially before implementation
 
 func evalObjectScriptWithEvaluator(src string) (core.Evaluator, core.Value, error) {
-	vals, err := parse.Parse(src)
+	vals, err := parse.ParseWithSource(src, "(test)")
 	if err != nil {
 		return nil, value.NewNoneVal(), err
 	}

--- a/test/contract/test_utils.go
+++ b/test/contract/test_utils.go
@@ -45,7 +45,7 @@ func NewTestEvaluator() *eval.Evaluator {
 
 // Evaluate is a helper function to evaluate Viro code in tests.
 func Evaluate(src string) (core.Value, error) {
-	vals, err := parse.Parse(src)
+	vals, err := parse.ParseWithSource(src, "(test)")
 	if err != nil {
 		return value.NewNoneVal(), err
 	}
@@ -60,7 +60,7 @@ func RunSeriesTest(t *testing.T, input string, want string, wantErr bool, errID 
 	t.Helper()
 
 	e := NewTestEvaluator()
-	tokens, parseErr := parse.Parse(input)
+	tokens, parseErr := parse.ParseWithSource(input, "(test)")
 	if parseErr != nil {
 		t.Fatalf("Parse error: %v", parseErr)
 	}

--- a/test/integration/eval_bench_test.go
+++ b/test/integration/eval_bench_test.go
@@ -15,7 +15,7 @@ var (
 
 func BenchmarkEvalSimpleExpression(b *testing.B) {
 	source := "1 + 2 * 3 - 4 + 5 / 2"
-	values, err := parse.Parse(source)
+	values, err := parse.ParseWithSource(source, "(test)")
 	if err != nil {
 		b.Fatalf("parse failed: %v", err)
 	}
@@ -62,7 +62,7 @@ loop 20 [
 ]
 total
 `
-	values, err := parse.Parse(source)
+	values, err := parse.ParseWithSource(source, "(test)")
 	if err != nil {
 		b.Fatalf("parse failed: %v", err)
 	}

--- a/test/integration/read_refinements_test.go
+++ b/test/integration/read_refinements_test.go
@@ -70,7 +70,7 @@ func TestReadRefinements(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			evaluator := NewTestEvaluator()
-			vals, parseErr := parse.Parse(tt.script)
+			vals, parseErr := parse.ParseWithSource(tt.script, "(test)")
 			if parseErr != nil {
 				t.Fatalf("Parse failed for %q: %v", tt.script, parseErr)
 			}
@@ -120,12 +120,12 @@ func TestReadRefinementsErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			evaluator := NewTestEvaluator()
-			vals, parseErr := parse.Parse(tt.script)
+			vals, parseErr := parse.ParseWithSource(tt.script, "(test)")
 			if parseErr != nil {
 				t.Fatalf("Parse failed for %q: %v", tt.script, parseErr)
 			}
 			_, err := evaluator.DoBlock(vals)
-			
+
 			if tt.shouldError && err == nil {
 				t.Errorf("Expected error but got none")
 			}
@@ -180,7 +180,7 @@ func TestReadRefinementsEdgeCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			evaluator := NewTestEvaluator()
-			vals, parseErr := parse.Parse(tt.script)
+			vals, parseErr := parse.ParseWithSource(tt.script, "(test)")
 			if parseErr != nil {
 				t.Fatalf("Parse failed for %q: %v", tt.script, parseErr)
 			}

--- a/test/integration/sc005_validation_test.go
+++ b/test/integration/sc005_validation_test.go
@@ -24,7 +24,7 @@ func TestSC005_PerformanceBaselines(t *testing.T) {
 		}
 
 		for _, expr := range simpleTests {
-			values, err := parse.Parse(expr)
+			values, err := parse.ParseWithSource(expr, "(test)")
 			if err != nil {
 				t.Fatalf("parse failed for %q: %v", expr, err)
 			}
@@ -84,7 +84,7 @@ func TestSC005_PerformanceBaselines(t *testing.T) {
 
 		for _, tt := range complexTests {
 			t.Run(tt.name, func(t *testing.T) {
-				values, err := parse.Parse(tt.code)
+				values, err := parse.ParseWithSource(tt.code, "(test)")
 				if err != nil {
 					t.Fatalf("parse failed: %v", err)
 				}

--- a/test/integration/us2_test.go
+++ b/test/integration/us2_test.go
@@ -22,7 +22,7 @@ func captureEvalOutput(t *testing.T, e core.Evaluator, script string) (string, c
 	oldWriter := e.GetOutputWriter()
 	e.SetOutputWriter(w)
 
-	vals, parseErr := parse.Parse(script)
+	vals, parseErr := parse.ParseWithSource(script, "(test)")
 	if parseErr != nil {
 		t.Fatalf("Parse failed for %q: %v", script, parseErr)
 	}
@@ -48,7 +48,7 @@ func captureEvalOutput(t *testing.T, e core.Evaluator, script string) (string, c
 
 func runScript(t *testing.T, e core.Evaluator, script string) (core.Value, error) {
 	t.Helper()
-	vals, parseErr := parse.Parse(script)
+	vals, parseErr := parse.ParseWithSource(script, "(test)")
 	if parseErr != nil {
 		t.Fatalf("Parse failed for %q: %v", script, parseErr)
 	}


### PR DESCRIPTION
## Summary
- ensure tokenizer tracks source names and attaches file/line metadata to syntax errors
- add ParseWithSource entry point and propagate file identifiers through parser consumers
- update tests to pass source hints and assert syntax errors include line/column information

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_690cd2138ee8832aa02515eb1f3ed7b0